### PR TITLE
Fix paths build due to undefined resourceFromAttributes()

### DIFF
--- a/src/instrumentation/edge.ts
+++ b/src/instrumentation/edge.ts
@@ -2,7 +2,7 @@
 import * as api from '@opentelemetry/api';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import type { ExportResult } from '@opentelemetry/core';
-import { resourceFromAttributes } from '@opentelemetry/resources';
+import { Resource } from '@opentelemetry/resources';
 import {
   BasicTracerProvider,
   type ReadableSpan,
@@ -49,16 +49,10 @@ export async function initTelemetry(sentryClient: VercelEdgeClient) {
   }
   const propagator = new SentryPropagator();
   const traceSampler = new SentrySampler(sentryClient);
-  const resource = resourceFromAttributes({
+  const resource = new Resource({
     [ATTR_SERVICE_NAME]: getProjectId(),
     [ATTR_SERVICE_VERSION]: getBuildId(),
   });
-  /*
-  const resource = resourceFromAttributes({
-    [ATTR_SERVICE_NAME]: getProjectId(),
-    [ATTR_SERVICE_VERSION]: getBuildId(),
-  });
-  */
   const provider = new BasicTracerProvider({
     resource,
     spanProcessors,

--- a/src/instrumentation/node.ts
+++ b/src/instrumentation/node.ts
@@ -1,7 +1,7 @@
 import { type Context, DiagConsoleLogger, DiagLogLevel, type Span, diag } from '@opentelemetry/api';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
-import { resourceFromAttributes } from '@opentelemetry/resources';
+import { Resource } from '@opentelemetry/resources';
 import { type ReadableSpan, type SpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
@@ -34,7 +34,7 @@ class GeneralSpanProcessor implements SpanProcessor {
     if (
       span.attributes['sentry.sentry_trace_backfill'] &&
       span.attributes['http.method'] &&
-      !span.parentSpanContext
+      !span.parentSpanId
     ) {
       delete span.attributes['sentry.sentry_trace_backfill'];
     }
@@ -71,7 +71,7 @@ export async function initTelemetry(sentryClient: NodeClient) {
     // Ensure the correct subset of traces is sent to Sentry
     // This also ensures trace propagation works as expected
     sampler: traceSampler,
-    resource: resourceFromAttributes({
+    resource: new Resource({
       [ATTR_SERVICE_NAME]: getProjectId(),
       [ATTR_SERVICE_VERSION]: getBuildId(),
     }),


### PR DESCRIPTION
While running a Paths build against the latest Kausal UI common, I see the following error:

```bash
TypeError: An error occurred while loading instrumentation hook: (0 , _opentelemetry_resources__WEBPACK_IMPORTED_MODULE_9__.resourceFromAttributes) is not a function
    at Module.initTelemetry (kausal_common/src/instrumentation/node.ts:74:37)
    at Module.initAll (kausal_common/src/instrumentation/node.ts:146:17)
    at async Module.register (src/instrumentation.ts:11:4)
  72 |     // This also ensures trace propagation works as expected
  73 |     sampler: traceSampler,
> 74 |     resource: resourceFromAttributes({
     |                                     ^
  75 |       [ATTR_SERVICE_NAME]: getProjectId(),
  76 |       [ATTR_SERVICE_VERSION]: getBuildId(),
  77 |     }),
```