### PR TITLE
Force system font on charts on all platforms

### DIFF
--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -85,6 +85,12 @@ export type ECOption = ComposeOption<
   | DatasetComponentOption
 >;
 
+const DEFAULT_STYLES: ECOption = {
+  textStyle: {
+    fontFamily: 'system-ui, sans-serif', // Force consistent font across platforms
+  },
+};
+
 type Props = {
   isLoading: boolean;
   data?: echarts.EChartsCoreOption;
@@ -156,7 +162,11 @@ export function Chart({
   // Update the chart when the data changes
   useEffect(() => {
     if (chartRef.current && data) {
-      chartRef.current.setOption(data, true);
+      const augmentedData = {
+        ...data,
+        ...DEFAULT_STYLES,
+      };
+      chartRef.current.setOption(augmentedData, true);
 
       if (withResizeLegend) {
         resizeLegend(chartRef.current);


### PR DESCRIPTION
Echart uses `"Microsoft YaHei"`, Chinese font as default on Windows platform. This causes a spacing errors on charts on Windows browsers. 

<img width="390" height="442" alt="Screenshot 2025-12-12 at 12 14 21" src="https://github.com/user-attachments/assets/412d8659-0b54-4456-8e95-cac1c9822946" />

-----
Force `'system-ui, sans-serif'` font for all charts to ensure best rendering quality of small type in Charts.

<img width="437" height="446" alt="Screenshot 2025-12-12 at 12 11 31" src="https://github.com/user-attachments/assets/cc427811-0817-4739-9bb4-749a8b07db59" />
