### PR TITLE
Add print CSS: page margins, font size, and container width

### DIFF
--- a/src/themes/ThemedGlobalStyles.tsx
+++ b/src/themes/ThemedGlobalStyles.tsx
@@ -228,7 +228,27 @@ const getGlobalStyles = (theme: Theme) => css`
     background-color: rgba(${theme.graphColors.red070}, 0.15);
   }
 
+  @page {
+    margin: 1.5cm;
+  }
+
   @media print {
+    html {
+      font-size: 10pt;
+    }
+
+    .container,
+    .container-fluid,
+    .container-sm,
+    .container-md,
+    .container-lg,
+    .container-xl,
+    .container-xxl {
+      max-width: 100% !important;
+      padding-left: 0 !important;
+      padding-right: 0 !important;
+    }
+
     p,
     h1,
     h2,


### PR DESCRIPTION
- Set @page margin to 1.5cm for consistent print margins
- Set html font-size to 10pt on print so rem-based sizing scales proportionally
- Override Bootstrap containers to full width with no padding on print