### PR TITLE
Fix paths node (area) graph regression

### DIFF
--- a/src/components/paths/DimensionalNodeVisualisation.tsx
+++ b/src/components/paths/DimensionalNodeVisualisation.tsx
@@ -155,24 +155,41 @@ export default function DimensionalNodeVisualisation({
     : null;
 
   // If we have category filters active, let's add them to the viz subtitle
-  const activeCategoryLabels: { dimension: string; categories: string[] }[] = [];
+  // Groups trump categories, so we check for groups first
+  const activeCategoryLabels: {
+    dimension: string;
+    categories: string[];
+    showDimension: boolean;
+  }[] = [];
   for (const [key, value] of Object.entries(sliceConfig.categories)) {
-    if (value?.categories?.length && value.categories.length > 0) {
+    const dim = parsedMetric.dimsById.get(key);
+    if (value?.groups?.length) {
       activeCategoryLabels.push({
-        dimension: parsedMetric.dimsById.get(key)?.label ?? '',
+        dimension: dim?.label ?? '',
+        categories: value.groups.map((groupId) => dim?.groupsById.get(groupId)?.label ?? ''),
+        showDimension: false,
+      });
+    } else if (value?.categories?.length) {
+      activeCategoryLabels.push({
+        dimension: dim?.label ?? '',
         categories: value.categories.map((catId) => {
-          for (const dim of parsedMetric.dimensions) {
-            const found = dim.categories.find((c) => c.id === catId);
+          for (const d of parsedMetric.dimensions) {
+            const found = d.categories.find((c) => c.id === catId);
             if (found) return found.label;
           }
           return '';
         }),
+        showDimension: true,
       });
     }
   }
 
   const subtitle = activeCategoryLabels
-    .map((dim) => `${dim.dimension}: ${dim.categories.join(' & ')}`)
+    .map((dim) =>
+      dim.showDimension
+        ? `${dim.dimension}: ${dim.categories.join(' & ')}`
+        : dim.categories.join(' & ')
+    )
     .join(', ')
     .trim();
 
@@ -426,6 +443,7 @@ export default function DimensionalNodeVisualisation({
           forecastTitle={forecastTitle}
           stackable={metric.stackable}
           chartType={chartType}
+          predictionLabel={t('table-scenario-forecast')}
         />
         {withTools && <ToolsMenu cube={parsedMetric} sliceConfig={sliceConfig} t={t} />}
       </Box>

--- a/src/components/paths/NodeGraph.tsx
+++ b/src/components/paths/NodeGraph.tsx
@@ -501,7 +501,7 @@ function createMainSeries(
               [
                 {
                   name: forecastTitle,
-                  xAxis: forecastAreaStartIndex,
+                  xAxis: forecastAreaStartIndex - (chartType === 'area' ? 1 : 0), // Adjust for bar width
                 },
                 {
                   x: '100%',
@@ -561,7 +561,8 @@ function createMainSeries(
       if (!hasForecast) return solidColor;
       const headerRow = dataset[datasetIndices.data].source![0];
       const totalXCategories = headerRow.length - 1; // subtract 'Category' column
-      const forecastRatio = forecastAreaStartIndex / Math.max(totalXCategories - 1, 1);
+      const forecastRatio =
+        Math.max(0, forecastAreaStartIndex - 1) / Math.max(totalXCategories - 1, 1);
       return {
         type: 'linear' as const,
         x: 0,


### PR DESCRIPTION
- Use groups instead of categories for visualisation title if available
- Make sure forecast tooltip has label
- In area graphs draw forecast range one year earlier for visual consistency with older versions

Before
<img width="735" height="355" alt="Screenshot 2026-04-15 at 17 29 52" src="https://github.com/user-attachments/assets/68ea47b5-f4d5-418e-baa8-f43364cbd538" />

After
<img width="648" height="314" alt="Screenshot 2026-04-15 at 17 30 19" src="https://github.com/user-attachments/assets/cd34c603-4c91-4272-9f59-f011cd0488ee" />
