### PR TITLE
Enable Charts to allow parent's requests for png export

### DIFF
--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -93,12 +93,9 @@ const DEFAULT_STYLES: ECOption = {
 };
 
 export type ChartHandle = {
-  getDataURL: (opts?: {
-    type?: 'png' | 'jpeg' | 'svg';
-    pixelRatio?: number;
-    backgroundColor?: string;
-    excludeComponents?: string[];
-  }) => string | undefined;
+  getDataURL: (
+    ...args: Parameters<echarts.ECharts['getDataURL']>
+  ) => ReturnType<echarts.ECharts['getDataURL']> | undefined;
 };
 
 type Props = {

--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { type Ref, useEffect, useImperativeHandle, useRef, useState } from 'react';
 
 import {
   BarChart,
@@ -92,6 +92,15 @@ const DEFAULT_STYLES: ECOption = {
   },
 };
 
+export type ChartHandle = {
+  getDataURL: (opts?: {
+    type?: 'png' | 'jpeg' | 'svg';
+    pixelRatio?: number;
+    backgroundColor?: string;
+    excludeComponents?: string[];
+  }) => string | undefined;
+};
+
 type Props = {
   isLoading: boolean;
   data?: echarts.EChartsCoreOption;
@@ -102,6 +111,7 @@ type Props = {
   withResizeLegend?: boolean;
   renderer?: 'svg' | 'canvas';
   locale?: string;
+  ref?: Ref<ChartHandle>;
 };
 
 export function Chart({
@@ -113,11 +123,20 @@ export function Chart({
   withResizeLegend = true,
   renderer = 'canvas',
   locale = 'en',
+  ref,
 }: Props) {
   const chartRef = useRef<echarts.ECharts | null>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const theme = useBaseTheme();
   const [isRendering, setIsRendering] = useState(true);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      getDataURL: (opts) => chartRef.current?.getDataURL(opts),
+    }),
+    []
+  );
 
   // Initialize the chart
   useEffect(() => {


### PR DESCRIPTION
Add handle for Charts to expose echart's download png function to the Chart's parent.

Related PR: https://github.com/kausaltech/kausal-paths-ui/pull/263