### PR TITLE
Update shared config compatibility for Next 16

### DIFF
--- a/configs/common-next-config.ts
+++ b/configs/common-next-config.ts
@@ -19,9 +19,6 @@ export function getNextConfig(projectRoot: string): NextConfig {
   const config: NextConfig = {
     assetPrefix: prodAssetPrefix,
     output: standaloneBuild ? 'standalone' : undefined,
-    eslint: {
-      ignoreDuringBuilds: true,
-    },
     typescript: {
       ignoreBuildErrors: true,
     },
@@ -57,7 +54,7 @@ export function getNextConfig(projectRoot: string): NextConfig {
         : undefined,
     },
     reactStrictMode: true,
-    skipMiddlewareUrlNormalize: true,
+    skipProxyUrlNormalize: true,
     serverExternalPackages: ['pino'],
     outputFileTracingIncludes: standaloneBuild
       ? { '/': ['./node_modules/@kausal*/themes*/**'] }

--- a/src/apollo/directives.ts
+++ b/src/apollo/directives.ts
@@ -1,5 +1,5 @@
-import type { ArgumentNode, DirectiveNode, VariableDefinitionNode } from 'graphql/language';
-import { Kind } from 'graphql/language';
+import type { ArgumentNode, DirectiveNode, VariableDefinitionNode } from 'graphql';
+import { Kind } from 'graphql';
 
 export type DirectiveArg = {
   name: string;

--- a/src/apollo/links.ts
+++ b/src/apollo/links.ts
@@ -9,6 +9,7 @@ import type { StartSpanOptions } from '@sentry/core';
 import * as Sentry from '@sentry/nextjs';
 import { Kind, type OperationDefinitionNode } from 'graphql';
 import type { Bindings } from 'pino';
+import { map } from 'rxjs/operators';
 
 import { isLocalDev, isProductionDeployment, isServer } from '@common/env';
 import { generateCorrelationID, getLogger } from '@common/logging';
@@ -45,7 +46,7 @@ const logOperation = new ApolloLink((operation, forward: NextLink) => {
 
   setContext({ ...ctx, start: Date.now(), logger: opLogger });
   opLogger.info(`Starting GraphQL request ${operationName}`);
-  return forward(operation).map((data) => {
+  return forward(operation).pipe(map((data) => {
     const context = operation.getContext() as DefaultApolloContext;
     const now = Date.now();
     const start = context.start;
@@ -70,7 +71,7 @@ const logOperation = new ApolloLink((operation, forward: NextLink) => {
       );
     }
     return data;
-  });
+  }));
 });
 
 export const logOperationLink = ApolloLink.from([logOperation, logErrorLink]);
@@ -144,7 +145,7 @@ export const createSentryLink = (uri: string) => {
           spanId: span.spanContext().spanId,
         };
       });
-      return forward(operation).map((result) => {
+      return forward(operation).pipe(map((result) => {
         if (result.errors) {
           span.setStatus({
             code: SPAN_STATUS_ERROR,
@@ -155,7 +156,7 @@ export const createSentryLink = (uri: string) => {
         }
         finish();
         return result;
-      });
+      }));
     });
   });
   return link;

--- a/src/sentry/sentry-next-config.ts
+++ b/src/sentry/sentry-next-config.ts
@@ -40,21 +40,24 @@ export function wrapWithSentryConfig(configIn: NextConfig): NextConfig {
       excludeDebugStatements: !sentryDebug,
       excludeReplayIframe: true,
     },
-    reactComponentAnnotation: {
-      enabled: true,
-    },
     telemetry: false,
-    // Automatically tree-shake Sentry logger statements to reduce bundle size
-    disableLogger: !sentryDebug,
-    excludeServerRoutes: [
-      API_HEALTH_CHECK_PATH,
-      HEALTH_CHECK_PUBLIC_PATH,
-      API_SENTRY_TUNNEL_PATH,
-      SENTRY_TUNNEL_PUBLIC_PATH,
-    ],
-    automaticVercelMonitors: false,
-    autoInstrumentMiddleware: false,
-    autoInstrumentServerFunctions: false,
+    webpack: {
+      reactComponentAnnotation: {
+        enabled: true,
+      },
+      treeshake: {
+        removeDebugLogging: !sentryDebug,
+      },
+      excludeServerRoutes: [
+        API_HEALTH_CHECK_PATH,
+        HEALTH_CHECK_PUBLIC_PATH,
+        API_SENTRY_TUNNEL_PATH,
+        SENTRY_TUNNEL_PUBLIC_PATH,
+      ],
+      automaticVercelMonitors: false,
+      autoInstrumentMiddleware: false,
+      autoInstrumentServerFunctions: false,
+    },
     sourcemaps: {
       deleteSourcemapsAfterUpload: false,
     },

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -1,0 +1,2 @@
+export { useTheme } from '@emotion/react';
+export type { Theme } from '@emotion/react';

--- a/src/themes/next-config.mjs
+++ b/src/themes/next-config.mjs
@@ -30,7 +30,7 @@ export function initializeThemes(rootDir) {
   const staticPath = join(rootDir, 'public', 'static');
   mkdirSync(staticPath, { recursive: true });
   const releaseThemeLock = lockfile.lockSync('public/static');
-  const require = createRequire(rootDir);
+  const require = createRequire(join(rootDir, 'package.json'));
   try {
     const destPath = join(rootDir, 'public', 'static', 'themes');
     const themesPrivate = tryImportThemePackage([

--- a/src/themes/styled.ts
+++ b/src/themes/styled.ts
@@ -1,0 +1,2 @@
+export { default } from '@emotion/styled';
+export * from './styles/styled';

--- a/src/themes/theme-init.server.ts
+++ b/src/themes/theme-init.server.ts
@@ -1,0 +1,1 @@
+export { loadTheme } from './theme';

--- a/src/themes/theme.ts
+++ b/src/themes/theme.ts
@@ -18,10 +18,13 @@ export async function loadTheme(themeIdentifier: string): Promise<Theme> {
       return JSON.parse(theme) as Theme;
     };
   } else {
-    const THEME_PATH = '/public/static/themes';
+    const THEME_PATH = '/static/themes';
     readThemeFile = async (id: string) => {
-      const theme = (await import(/* @vite-ignore */ `${THEME_PATH}/${id}/theme.json`)) as { default: Theme };
-      return theme.default;
+      const response = await fetch(`${THEME_PATH}/${id}/theme.json`);
+      if (!response.ok) {
+        throw new Error(`Failed to load theme ${id}: ${response.status}`);
+      }
+      return (await response.json()) as Theme;
     };
   }
   try {


### PR DESCRIPTION
Adjust the shared Next, Sentry, Apollo, and theme compatibility layer for the newer toolchain. This updates deprecated Next 16 config keys, adapts Apollo link code to the current observable API, restores theme entry points expected by consuming apps, and removes Turbopack-incompatible theme loading so apps using the updated submodule continue to boot and serve requests correctly.

This has been vibe-coded and I don't really know what I'm doing, so please check. :grimacing: The goal was to make the current KP UI work with the latest version of this repo.

## Related issue
[kausal-paths-ui PR](https://github.com/kausaltech/kausal-paths-ui/pull/266)