### PR TITLE
Resize chart if its height prop changes

### DIFF
--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -183,6 +183,17 @@ export function Chart({
     }
   }, [isLoading]);
 
+  // ECharts caches the canvas size at init time and otherwise only reacts to
+  // window-resize events, so changing the `height` prop must explicitly notify it.
+  useEffect(() => {
+    const chart = chartRef.current;
+    if (!chart) return;
+    chart.resize();
+    if (withResizeLegend) {
+      resizeLegend(chart);
+    }
+  }, [height, withResizeLegend]);
+
   // Update the chart when the data changes
   useEffect(() => {
     if (chartRef.current && data) {


### PR DESCRIPTION
Fixes the bug where graphs that render on specific height depending on data items glitch when data changes.

<img width="722" height="471" alt="Screenshot 2026-05-12 at 11 41 36" src="https://github.com/user-attachments/assets/331223cf-589a-422c-a1ef-5a2f4317ab70" />
